### PR TITLE
FEAT. openAI chatGPT(4o-mini) API chatCompletion

### DIFF
--- a/Devlog/build.gradle
+++ b/Devlog/build.gradle
@@ -24,6 +24,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springAiVersion', "1.1.0")
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
@@ -68,7 +72,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     
+    // Chatbot
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
 }
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
+}
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/Devlog/src/main/java/com/devlog/project/chatbotTemplate/controller/ChatbotController.java
+++ b/Devlog/src/main/java/com/devlog/project/chatbotTemplate/controller/ChatbotController.java
@@ -1,0 +1,30 @@
+package com.devlog.project.chatbotTemplate.controller;
+
+
+import org.springframework.web.bind.annotation.*;
+
+import com.devlog.project.chatbotTemplate.service.ChatbotService;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/chat")
+public class ChatbotController {
+
+    private final ChatbotService chatService;
+    public ChatbotController(ChatbotService chatService){ this.chatService = chatService; }
+
+    @PostMapping("/{sessionId}")
+    //public Map<String,Object> chat(@PathVariable("sessionId")  String sessionId, @RequestBody String message){
+    public Map<String,Object> chat(@PathVariable  String sessionId, @RequestBody String message){
+        return chatService.sendMessage(sessionId, message);
+    }
+
+    @PostMapping("/lastAnswer")
+    public Map<String,Object> lastAnswer(@RequestBody Map<String,String> payload){
+        String sessionId = payload.get("sessionId");
+        String question = payload.get("lastQuestion");
+        String answer = payload.get("lastAiAnswer");
+        return chatService.sendLastAnswer(sessionId, question, answer);
+    }
+}

--- a/Devlog/src/main/java/com/devlog/project/chatbotTemplate/service/ChatbotService.java
+++ b/Devlog/src/main/java/com/devlog/project/chatbotTemplate/service/ChatbotService.java
@@ -1,0 +1,88 @@
+package com.devlog.project.chatbotTemplate.service;
+
+
+import org.springframework.stereotype.Service;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.ai.openai.*;
+import org.springframework.ai.chat.messages.*;
+//import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+//import org.springframework.ai.openai.api.OpenAiApi.Usage;
+//import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.*;
+
+import java.util.*;
+
+@Getter
+@Setter
+@Service
+public class ChatbotService {
+
+    private final OpenAiChatModel chatModel;
+    private final Map<String, Integer> tokenMap = new HashMap<>();
+
+    public ChatbotService(OpenAiChatModel chatModel){
+        this.chatModel = chatModel;
+    }
+
+    public Map<String,Object> sendMessage(String sessionId, String message){
+        ChatResponse response = chatModel.call(
+                new Prompt(List.of(new UserMessage(message)))
+        );
+
+        //String reply = response.getResult().getOutput().getContent(); // Spring AI 0.1.x 이전
+        String reply = response.getResult().getOutput().getText(); // Spring AI 0.1.x 이후
+        
+////        Usage usage = response.getUsage(); // Spring AI 0.1.x 이전
+//        OpenAiChatResponseMetadata meta = // Spring AI 0.1.x 이후
+//                (OpenAiChatResponseMetadata) response.getMetadata();
+//        Usage usage = meta.usage();
+        
+        
+
+//        int serverTokens = usage.getTotalTokens();
+//        tokenMap.put(sessionId, tokenMap.getOrDefault(sessionId,0) + serverTokens);
+
+        return Map.of(
+                  "reply", reply,
+	              "usage", Map.of(
+				              "prompt_tokens", 7, // dummy value for usage.getPromptTokens(),
+				              "completion_tokens", 7, // dummy value for usage.getCompletionTokens(),
+				              "total_tokens", 7, // dummy value for serverTokens,
+				              "accumulated_tokens", 777 // dummy value for tokenMap.get(sessionId)
+			            	)
+        );
+    }
+
+    public Map<String,Object> sendLastAnswer(String sessionId, String question, String answer){
+
+        ChatResponse response = chatModel.call(
+                new Prompt(List.of(
+                        new UserMessage("이전 질문: "+question),
+                        new AssistantMessage("이전 답변: "+answer),
+                        new UserMessage("이전 답변을 참고해서 다시 설명해줘.")
+                ))
+        );
+
+        //String reply = response.getResult().getOutput().getContent();// Spring AI 0.1.x 이전
+        String reply = response.getResult().getOutput().getText(); // Spring AI 0.1.x 이후
+        //Usage usage = response.getUsage();
+
+//        int serverTokens = usage.getTotalTokens();
+//        tokenMap.put(sessionId, tokenMap.getOrDefault(sessionId,0) + serverTokens);
+
+        return Map.of(
+                "reply", reply,
+                "usage", Map.of(
+                        "prompt_tokens", 7, // dummy data for usage.getPromptTokens(),
+                        "completion_tokens", 7, // dummy data for usage.getCompletionTokens(),
+                        "total_tokens", 7, // dummy data for serverTokens,
+                        "accumulated_tokens", 777 //dummy data for tokenMap.get(sessionId)
+                )                
+        );
+    }
+}
+

--- a/Devlog/src/main/java/com/devlog/project/chatbotTemplate/websocket/ChatbotWebSocketHandler.java
+++ b/Devlog/src/main/java/com/devlog/project/chatbotTemplate/websocket/ChatbotWebSocketHandler.java
@@ -1,0 +1,43 @@
+package com.devlog.project.chatbotTemplate.websocket;
+
+
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.ai.openai.*;
+import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.*;
+
+@Component
+public class ChatbotWebSocketHandler extends TextWebSocketHandler {
+
+    private final OpenAiChatModel chatModel;
+
+    public ChatbotWebSocketHandler(OpenAiChatModel chatModel){
+        this.chatModel = chatModel;
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+
+        ChatResponse response = chatModel.call(
+                new Prompt(new UserMessage(message.getPayload()))
+        );
+
+        //String reply = response.getResult().getOutput().getContent();// Spring AI 0.1.x 이전
+        String reply = response.getResult().getOutput().getText(); // Spring AI 0.1.x 이후
+        System.out.println("[Chat GPT] Answer: " + reply);
+        //int tokens = response.getUsage().getTotalTokens();
+        int tokens = 777; // dummy value
+
+        String json = """
+            {
+              "reply": "%s",
+              "usage": { "total_tokens": %d }
+            }
+        """.formatted(reply.replace("\"","\\\""), tokens);
+
+        session.sendMessage(new TextMessage(json));
+    }
+}

--- a/Devlog/src/main/java/com/devlog/project/chatbotTemplate/websocket/WebSocketConfig.java
+++ b/Devlog/src/main/java/com/devlog/project/chatbotTemplate/websocket/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package com.devlog.project.chatbotTemplate.websocket;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final ChatbotWebSocketHandler handler;
+
+    public WebSocketConfig(ChatbotWebSocketHandler handler){
+        this.handler = handler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry){
+        registry.addHandler(handler, "/ws/chat").setAllowedOrigins("*");
+    }
+}

--- a/Devlog/src/main/resources/application.yml
+++ b/Devlog/src/main/resources/application.yml
@@ -24,8 +24,36 @@ spring :
                   enable : true
    config :
       import : config.properties 
-      
+        
+   ai:
+      openai:
+         api-key: ${OPENAI_API_KEY:}
+         chat:
+            options:
+               model: gpt-4o-mini  
+     
+   datasource:
+      driver-class-name: oracle.jdbc.driver.OracleDriver
+      url: jdbc:oracle:thin:@localhost:1521:xe
+      username: project
+      password: project1234
+      hikari:
+         connection-timeout: 30000
+         maximum-pool-size: 20
+         idle-timeout: 600000
+         pool-name: MyHikariCP
+         auto-commit: false
+
+   servlet:
+      multipart:
+         file-size-threshold: 52428800
+         max-file-size: 10485760
+         max-request-size: 52428800     
+     
 logging:
   level:
      org.elasticsearch.client : TRACE # Elasticsearch 쿼리 로그 출력 
      edu.og.es.common.filter.LoggingFilter : Trace # 필터 로그     
+     
+server:
+   port: 8880

--- a/Devlog/src/main/resources/static/chatbotTemplate.html
+++ b/Devlog/src/main/resources/static/chatbotTemplate.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>OpenAI Chat</title>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style>
+body{margin:0;font-family:sans-serif;background:#f4f7fb;display:flex;flex-direction:column;height:100vh;}
+header{background:#BD83CE;color:#fff;padding:15px;text-align:center;font-size:20px;}
+.chat-container{flex:1;overflow-y:auto;padding:20px;}
+.bubble{max-width:70%;padding:12px;border-radius:14px;margin-bottom:12px;position:relative;}
+.bubble.user{margin-left:auto;background:#BD83CE;color:#f4f7fb;}
+.bubble.ai{margin-right:auto;background:#fff;border:1px solid #ccc;}
+.copy-btn{position:absolute;right:8px;top:4px;font-size:10px;display:none;}
+.bubble:hover .copy-btn{display:block;}
+.token-counter{padding:10px;background:#e2e6ef;text-align:right;font-size:13px;}
+.input-area{display:flex;background:white;padding:10px;}
+.input-area input{flex:1;padding:12px;border-radius:10px;border:1px solid #ccc;}
+.input-area button{margin-left:8px;padding:12px;border:none;background:#BD83CE;color:white;border-radius:10px;}
+</style>
+</head>
+<body>
+
+<header>OpenAI Chat</header>
+<div class="chat-container" id="chat"></div>
+
+<div class="token-counter" id="tokens">
+서버 계산 토큰: 0 | 클라이언트 추정 토큰: 0
+</div>
+
+<div class="input-area">
+  <input id="msg" placeholder="메시지 입력..." onkeydown="if(event.key==='Enter') send();">
+  <button onclick="send()">보내기</button>
+  <button onclick="useLast()">마지막답변</button>
+</div>
+
+<script>
+const chat = document.getElementById("chat");
+const tokens = document.getElementById("tokens");
+const sessionId = "session1";
+
+let lastQuestion="", lastAiAnswer="";
+let totalServer=0, totalClient=0;
+
+const ws = new WebSocket("ws://localhost:8080/ws/chat");
+ws.onmessage = e => {
+    const d=JSON.parse(e.data);
+    showAi(d.reply,d.usage.total_tokens);
+};
+
+function tokenCalc(str){ return Math.ceil(str.length/4); }
+
+function updateTokens(){
+    tokens.textContent = "서버 계산 토큰: "+totalServer+
+                         " | 클라이언트 추정 토큰: "+totalClient;
+}
+
+function showUser(t){
+    showBubble(t,"user");
+    totalClient+=tokenCalc(t);
+    updateTokens();
+}
+
+function showAi(t,serverTokens){
+    lastAiAnswer=t;
+    showBubble(t,"ai",true);
+
+    totalServer+=serverTokens;
+    totalClient+=tokenCalc(t);
+
+    updateTokens();
+}
+
+function showBubble(text,role,md=false){
+    const b=document.createElement("div"); b.className="bubble "+role;
+    const copy=document.createElement("button"); copy.textContent="복사"; copy.className="copy-btn";
+    copy.onclick=()=>navigator.clipboard.writeText(text); b.appendChild(copy);
+
+    const c=document.createElement("div");
+    c.innerHTML = md ? marked.parse(text) : text;
+    b.appendChild(c);
+
+    chat.appendChild(b);
+    chat.scrollTop=chat.scrollHeight;
+}
+
+function send(){
+    const msg=document.getElementById("msg").value.trim();
+    if(!msg) return;
+    document.getElementById("msg").value="";
+    
+    lastQuestion=msg;
+    showUser(msg);
+
+    fetch("/api/chat/"+sessionId,{method:"POST",headers:{"Content-Type":"text/plain"},body:msg})
+       .then(r=>r.json())
+       .then(d=>showAi(d.reply,d.usage.total_tokens));
+
+    ws.send(msg);
+}
+
+function useLast(){
+    if(!lastAiAnswer || !lastQuestion){ alert("기록 없음"); return; }
+    showUser("(마지막답변 사용)");
+
+    fetch("/api/chat/lastAnswer",{method:"POST",headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({sessionId,lastQuestion,lastAiAnswer})})
+    .then(r=>r.json())
+    .then(d=>showAi(d.reply,d.usage.total_tokens));
+}
+</script>
+
+</body>
+</html>

--- a/Devlog/src/main/resources/static/index.html
+++ b/Devlog/src/main/resources/static/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>AI Chat Launcher</title>
+<style>
+body { display:flex; justify-content:center; align-items:center; height:100vh; background:#f4f4f4; font-family:sans-serif; }
+button { padding:16px 30px; font-size:18px; border:none; background:#BD83CE; color:white; border-radius:8px; cursor:pointer; }
+button:hover { background:#E5B0EA; }
+</style>
+</head>
+<body>
+
+<button onclick="openChat()">AI 채팅 시작하기</button>
+
+<script>
+function openChat(){
+    window.open("chatbotTemplate.html","chat","width=520,height=760");
+}
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
openAI chatGPT(4o-mini) API chatCompletion(질의/응답) 가능하게 되었습니다.
meta정보를 받아오는 것은 이슈가 있는데 Spring AI에서 제공하는 버전정보가 불명확하여 해결못했습니다.

프로그램 빌드/실행상 이슈로는
1. 이전에 application.properties와 config.properties로 나누던 방식이 문제가 없었으나,
application.yml과 config.properties 방식으로 나누어졌을때 프로그램 실행이않됨=> application.yml 에 DB정보를 같이 넣어주면 실행되어 그렇게 했음.
2.프로젝트환경설정에서 Java Compiler => Store information about method parameters (usable via reflection)체크되어야함.

그외 특이 사항은 없습니다. 확인해 보시고 머지해주세요.


