### PR TITLE
FEAT. 카카오 소셜 로그인 기능추가

### DIFF
--- a/Devlog/src/main/java/com/devlog/project/common/config/SecurityConfig.java
+++ b/Devlog/src/main/java/com/devlog/project/common/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
 	                ,"/checkCode/**"
 	                ,"/board/freeboard/**"
 	                ,"/app/login/**"
+	                ,"/member/signUpKakao"	                
 	                ///// PYY API Addition End: /////	                
 	                ,"/blog/**"
 	                ,"/api/blog/**"

--- a/Devlog/src/main/java/com/devlog/project/member/controller/EmailController.java
+++ b/Devlog/src/main/java/com/devlog/project/member/controller/EmailController.java
@@ -25,7 +25,7 @@ public class EmailController {
 
 	@GetMapping("/signUp")
 	@ResponseBody
-	public int signUp(String email) {
+	public int signUp(@RequestParam("email") String email) {
 		return emailServiceJpa.signUp(email, "회원 가입") ? 1 :0;
 	}
 

--- a/Devlog/src/main/java/com/devlog/project/member/controller/KakaoSocialLoginController.java
+++ b/Devlog/src/main/java/com/devlog/project/member/controller/KakaoSocialLoginController.java
@@ -1,0 +1,59 @@
+package com.devlog.project.member.controller;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.devlog.project.member.model.dto.MemberKakaoSocialLoginResponseDTO;
+import com.devlog.project.member.model.service.KakaoSocialLoginService;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller // @Controller: 리턴값을 "뷰이름"으로 해석, @RestController: 리턴값을 HTTP Body(JSON)로 해석 
+			// => ResponseEntity는 자동으로 Body(JSON)이 아님 => @RestController 또는 @Controller + @ResponseBody 이어야함
+@RequestMapping("/app/login")  // GET and POST 다 처리
+@RequiredArgsConstructor 
+public class KakaoSocialLoginController {
+
+    private final KakaoSocialLoginService kakaoSocialLoginService;
+     	
+    @GetMapping("/kakao")
+    public String kakaoAuthServer() { // window.location.href = "/app/login/kakao"; 로 전달되는 query string parameter 없음
+    	
+    		return "redirect:" + kakaoSocialLoginService.getKakaoAuthUrl();
+    } // JS 카카오 로그인 버튼 클릭 =>  콘트롤러 => 카카오 인증 서버로 리다이렉트
+    
+    
+    @GetMapping("/kakao/callback") // 카카오 인증 서버에서 인증후 받아온 인가코드 => 콘트롤러에서 인가코드로 => 카카오에서서 accessToken받아오기 => accessToken으로 kakaoId, 사용자정보 얻어오기 => 서비스 웹사이트 로그인 처리 마무리(MEMBER, SOCIAL_LOGIN DB 작업등)
+    public String kakaoCallback(@RequestParam("code") String code
+    							, HttpSession session
+    							, RedirectAttributes ra
+    							) {
+    	MemberKakaoSocialLoginResponseDTO memberKakaoDTO = kakaoSocialLoginService.processKakaoLogin(code); // SocialLogin DB에 있을시 회원정보다 받기
+        log.info("[ memberKakaoDTO ] =>  { }", memberKakaoDTO);
+        
+        if (memberKakaoDTO.getMemberDTO() != null) { // 기존 SOCAIL_LOGIN DB에 있는 멤버
+            session.setAttribute("loginMember", memberKakaoDTO.getMemberDTO());
+            return "redirect:/"; // kakao 로그인 후 메인 페이지로
+        } else { // 기존 SOCAIL_LOGIN DB에 없는 최초 kakao 로그인 멤버 
+            session.setAttribute("kakaoId", memberKakaoDTO.getKakaoId()); // signUp에서 사용할 수 있도록 카카오 id 저장
+            
+            String message = "카카오 로그인에 성공했습니다.\n" + 
+            				 "DevLog 서비스를 원활히 이용하시기 위해서는 필수 회원 정보가 필요합니다.\n" + 
+            				 "회원 정보를 입력해 주세요. 감사합니다.";	
+            ra.addFlashAttribute("message", message);
+            
+            return "redirect:/member/signUpKakao";
+        }
+    }    
+    
+}

--- a/Devlog/src/main/java/com/devlog/project/member/controller/MemberController.java
+++ b/Devlog/src/main/java/com/devlog/project/member/controller/MemberController.java
@@ -252,6 +252,49 @@ public class MemberController {
 		return path;
     }		
 	
+
 	
+	// 필수 회원정보 입력 페이지(전용화면) 이동: GET방식
+	@GetMapping("/signUpKakao")
+	public String signUpKakaoPage() {
+	    return "member/signUpKakao"; //  Thymeleaf
+	}
+	
+	
+	// 필수 회원정보 입력 진행 // 아이디(이메일), 비밀번호, 이름, 닉네임, 전화번호, 경력사항, 이메일 수신동의
+	// 카카오 로그인한 유저가 SOCIAL_LOGIN DB에 레코드없을 경우(최초 카카오로그인경우), 회원가입 절차진행 
+	@PostMapping("/signUpKakao")  
+    public String signUpKakao( 
+    		 @ModelAttribute  MemberSignUpRequestDTO request  
+    		 , RedirectAttributes ra
+    		 , HttpSession session
+    ) {
+		log.info("signUp email = {}", request.getMemberEmail());
+		log.info("###@@@%%% CONTROLLER DTO = {}", request);
+
+		String path = "redirect:";
+		String message = null;
+		int result=0; // placeholder
+		
+		try { // 회원가입 성공
+			String kakaoId = (String)session.getAttribute("kakaoId");
+			MemberLoginResponseDTO loginMemberKakao = service.signUpKakao(request, kakaoId); // MemberService2에서 signUp 처리, signUp 실패시 예외 발생 -> controller에서 성공(1) 실패(0)처리 반환
+			session.setAttribute("loginMember", loginMemberKakao);
+			result = 1;
+			
+			path += "/"; //메인페이지로 (JS에서?)
+			message = request.getMemberNickname() + "님, 회원정보를 입력해 주셔서 감사합니다.";	 // (JS에서?)
+		} catch(Exception e) { // 회원가입 실패
+			log.error("회원가입 실패", e);
+			result = 0;
+			path += "/member/signUpKakao"; //다시 회원가입 페이지로 
+			message = "서버 오류로 회원 정보입력에 실패했습니다.\n 잠시후 다시 이용해 주세요.";				
+		}
+		
+		ra.addFlashAttribute("message", message);
+		
+		return path;
+    }	
+		
 	
 }

--- a/Devlog/src/main/java/com/devlog/project/member/model/dto/KakaoSocialLoginResponseDTO.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/dto/KakaoSocialLoginResponseDTO.java
@@ -1,0 +1,23 @@
+package com.devlog.project.member.model.dto;
+
+
+import com.devlog.project.member.model.entity.Member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class KakaoSocialLoginResponseDTO {
+    private Long socialNo;
+	private String provider;
+	private String providerId;
+	//private MemberLoginResponseDTO member;
+	private Long memberNo; // memberNo = member.getMemberNo()
+}

--- a/Devlog/src/main/java/com/devlog/project/member/model/dto/MemberKakaoSocialLoginResponseDTO.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/dto/MemberKakaoSocialLoginResponseDTO.java
@@ -1,0 +1,23 @@
+package com.devlog.project.member.model.dto;
+
+import java.time.LocalDateTime;
+
+import com.devlog.project.member.enums.CommonEnums.Status;
+import com.devlog.project.member.model.entity.Level;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class MemberKakaoSocialLoginResponseDTO {
+	
+	private MemberLoginResponseDTO memberDTO;
+	
+    // for kakao social login
+    private String accessToken;
+    private String kakaoId;
+    
+}

--- a/Devlog/src/main/java/com/devlog/project/member/model/entity/SocialLogin.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/entity/SocialLogin.java
@@ -1,0 +1,76 @@
+package com.devlog.project.member.model.entity;
+
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+//import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table( // ALTER TABLE SOCIAL_LOGIN ADD CONSTRAINT UK_SOCIAL_LOGIN UNIQUE (PROVIDER, PROVIDER_ID); 에 대응되게 Entity 설정
+	    name = "SOCIAL_LOGIN",
+	    uniqueConstraints = {
+	        @UniqueConstraint(
+	            name = "UK_SOCIAL_LOGIN",
+	            columnNames = {"PROVIDER", "PROVIDER_ID"}
+	        )
+	    }
+	)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor // 객체생성에 필요
+@ToString
+public class SocialLogin { // 
+
+	// PK
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_SOCIAL_LOGIN")
+    @SequenceGenerator(
+            name = "SEQ_SOCIAL_LOGIN",
+            sequenceName = "SEQ_SOCIAL_LOGIN_NO",
+            allocationSize = 1
+    )
+    @Column(name = "SOCIAL_NO")
+    private Long socialNo;
+    
+    
+    // 소셜로그인 제공자 // "KAKAO"
+    @Column(name = "PROVIDER", nullable = false, length = 30)
+    private String provider;
+
+    // 소셜로그인 제공자서비스에서의 식별자(ex: 카카오 사용자 id) // kakaoId
+    @Column(name = "PROVIDER_ID", nullable = false, length = 100)
+    private String providerId;
+    
+    // 멤버 테이블키 참조 (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_NO", nullable = false)
+    private Member memberNo;	// Member Entity
+	
+    // 생성자 (소셜로그인용)
+    @Builder // @Builder가 필드가 아닌 생성자에 붙어 있음 =>이 경우 생성자 파라미터 이름 기준으로 builder 메서드가 만들어짐
+    public SocialLogin(String provider, String providerId, 
+                  Member memberNo) {
+
+        this.provider = provider;
+        this.providerId = providerId;
+        
+        // FK (MEMBER 테이블)
+        this.memberNo = memberNo; // Member Entity
+    }	
+}

--- a/Devlog/src/main/java/com/devlog/project/member/model/repository/KakaoSocialLoginRepository.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/repository/KakaoSocialLoginRepository.java
@@ -1,0 +1,12 @@
+package com.devlog.project.member.model.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.devlog.project.member.model.entity.SocialLogin;
+
+public interface KakaoSocialLoginRepository extends JpaRepository<SocialLogin, Long>{
+
+	Optional<SocialLogin> findByProviderAndProviderId(String provider, String providerId);
+}

--- a/Devlog/src/main/java/com/devlog/project/member/model/service/KakaoSocialLoginService.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/service/KakaoSocialLoginService.java
@@ -1,0 +1,181 @@
+package com.devlog.project.member.model.service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import com.devlog.project.member.enums.CommonEnums.Status;
+import com.devlog.project.member.model.dto.KakaoSocialLoginResponseDTO;
+import com.devlog.project.member.model.dto.LevelDTO;
+import com.devlog.project.member.model.dto.MemberKakaoSocialLoginResponseDTO;
+import com.devlog.project.member.model.dto.MemberLoginResponseDTO;
+import com.devlog.project.member.model.entity.Level;
+import com.devlog.project.member.model.entity.Member;
+import com.devlog.project.member.model.entity.SocialLogin;
+import com.devlog.project.member.model.repository.MemberRepository;
+import com.devlog.project.member.model.repository.KakaoSocialLoginRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoSocialLoginService {
+
+    private final KakaoSocialLoginRepository socialLoginRepository;
+    private final MemberRepository memberRepository;
+    private final RestTemplate restTemplate = new RestTemplate();	
+	
+    @Value("${KAKAO_REDIRECT_URI}") // pring 파일에서는 @Value를 통해서 application.yml에 ${KAKAO_REDIRECT_URI}로 정의된 환경변수, env 값을 가져올 수 있다.
+    private String kakao_redirect_uri;    
+    
+    @Value("${KAKAO_REST_API_KEY}")
+    private String kakao_rest_api_key;    
+    
+    @Value("${KAKAO_CLIENT_SECRET}")
+    private String kakao_client_secret;       
+    
+    
+    public String getKakaoAuthUrl() {
+        return "https://kauth.kakao.com/oauth/authorize" +
+               "?response_type=code" +
+               "&client_id=" + kakao_rest_api_key +
+               "&redirect_uri=" + URLEncoder.encode(kakao_redirect_uri, StandardCharsets.UTF_8);
+    }
+    
+    
+    @Transactional(readOnly = true)
+    public MemberKakaoSocialLoginResponseDTO processKakaoLogin(String code) {
+        // 1. 카카오 access token 요청
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String body = "grant_type=authorization_code" +
+                "&client_id="+ kakao_rest_api_key +
+                "&client_secret=" + kakao_client_secret +
+                "&redirect_uri=" + kakao_redirect_uri +
+                "&code=" + code;
+
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(tokenUrl, request, String.class); // 실제요청보내고/응답받기
+
+        JSONObject json = null;
+		try {
+			json = new JSONObject(response.getBody());
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+        String accessToken = null;
+		try {
+			accessToken = json.getString("access_token");
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+
+		log.info("[ accessToken ] =>  { } ", accessToken);
+		
+        // 2. 사용자 정보 가져오기
+        HttpHeaders userHeaders = new HttpHeaders();
+        userHeaders.setBearerAuth(accessToken);
+        HttpEntity<Void> userRequest = new HttpEntity<>(userHeaders);
+
+        ResponseEntity<String> userResponse = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                userRequest,
+                String.class
+        ); // 실제요청보내고/응답받기
+
+        JSONObject userJson = null;
+		try {
+			userJson = new JSONObject(userResponse.getBody());
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+		
+        String kakaoId = null;
+		try {
+			kakaoId = String.valueOf(userJson.getLong("id"));
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+		
+		log.info("[ kakaoId ] =>  { } ", kakaoId);
+
+        // 3. SOCIAL_LOGIN DB 조회
+        Optional<SocialLogin> socialOpt = socialLoginRepository.findByProviderAndProviderId("kakao", kakaoId);
+        if (socialOpt.isPresent()) { // SOCIAL_LOGIN DB에 존재
+        	Member member = socialOpt.get().getMemberNo(); // socialOpt.get().getMemberNo()는 실제로 Member Entity 
+        	
+        	// for double-checking: member vs. loginMemberKakao
+        	Long memberNo = member.getMemberNo(); // memberNo만 꺼내서 Long memberNo를 반환할수도 있다
+        	Optional<Member> loginMemberKakao = memberRepository.findById(memberNo); // loginMember_kakao는 socialOpt.get().getMemberNo()와 같아야함
+        	log.info("[ member checking ] =>  { } ", member.getMemberEmail().equals(loginMemberKakao.get().getMemberEmail()));
+        	
+        	// 이제 MemberLoginResponseDTO 만들자.
+            String role =  member.getMemberAdmin() == Status.N ? "ROLE_USER" : "ROLE_ADMIN";
+        	Level level = member.getMemberLevel(); // LAZY 초기화 (트랜잭션 안)
+
+            LevelDTO levelDTO = new LevelDTO(
+                level.getLevelNo(),
+                level.getTitle(),
+                level.getRequiredTotalExp()
+            );        	
+            
+            MemberLoginResponseDTO memberDTO = new MemberLoginResponseDTO(
+                    member.getMemberNo(),
+                    member.getMemberEmail(),
+                    member.getMemberNickname(),
+                    role,
+                    member.getMemberAdmin(),
+                    member.getMemberSubscribe(),
+                    member.getMemberDelFl(),
+                    member.getMemberCareer(),
+                    member.getProfileImg(),
+                    member.getMyInfoIntro(),
+                    member.getMyInfoGit(),
+                    member.getMyInfoHomepage(),
+                    member.getSubscriptionPrice(),
+                    member.getBeansAmount(),
+                    member.getCurrentExp(),
+                    member.getMCreateDate(),
+                    levelDTO
+                    );
+            
+            MemberKakaoSocialLoginResponseDTO memberKakaoDTO = new MemberKakaoSocialLoginResponseDTO(
+            		memberDTO,
+                    accessToken, // for kakao social login
+                    kakaoId // for kakao social login
+        			);
+        	
+        	return memberKakaoDTO; // kakao 소셜 로그인한 기존 회원 정보반환 
+        	
+        } else { // SOCIAL_LOGIN DB에 존재하지 않을 때
+        	
+            MemberKakaoSocialLoginResponseDTO memberKakaoDTO = new MemberKakaoSocialLoginResponseDTO(
+            		null,
+                    accessToken, // for kakao social login
+                    kakaoId // for kakao social login
+        			);        	   	
+           	
+            return memberKakaoDTO; // 신규 회원이면 memberKakaoDTO.memberDTO = null 반환 -> 컨트롤러에서 signUp으로 redirect
+        }
+    }
+    
+}

--- a/Devlog/src/main/java/com/devlog/project/member/model/service/MemberService.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/service/MemberService.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class MemberService {
+public class MemberService {  // 로그인(login) 서비스 전용
 
     @Transactional(readOnly = true)
     public MemberLoginResponseDTO toLoginResponse(Member member,

--- a/Devlog/src/main/java/com/devlog/project/member/model/service/MemberService2.java
+++ b/Devlog/src/main/java/com/devlog/project/member/model/service/MemberService2.java
@@ -4,14 +4,19 @@ package com.devlog.project.member.model.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devlog.project.member.enums.CommonEnums.Status;
+import com.devlog.project.member.model.dto.LevelDTO;
+import com.devlog.project.member.model.dto.MemberLoginResponseDTO;
 import com.devlog.project.member.model.dto.MemberSignUpRequestDTO;
 import com.devlog.project.member.model.entity.Level;
 import com.devlog.project.member.model.entity.Member;
+import com.devlog.project.member.model.entity.SocialLogin;
+import com.devlog.project.member.model.repository.KakaoSocialLoginRepository;
 import com.devlog.project.member.model.repository.LevelRepository;
 import com.devlog.project.member.model.repository.MemberRepository;
 
@@ -20,13 +25,15 @@ import com.devlog.project.member.model.repository.MemberRepository;
 @Service
 @RequiredArgsConstructor
 @Transactional // 회원가입은 하나의 트랜잭션
-public class MemberService2 {
+public class MemberService2 { // 회원가입(signUp) 서비스 전용
 
     private final MemberRepository memberRepository;
     private final LevelRepository levelRepository;
     private final PasswordEncoder passwordEncoder;
-
-    public void signUp(MemberSignUpRequestDTO dto) {
+    //
+    private final KakaoSocialLoginRepository kakaoSocialLoginRepository;
+    
+    public void signUp(MemberSignUpRequestDTO dto) { // devlog.com 사이트 통한 회원가입 => 이후 로그인 =>서비스 이용
 
     	log.info("email = {}", dto.getMemberEmail());
     	log.info("pw = {}", dto.getMemberPw());
@@ -57,4 +64,99 @@ public class MemberService2 {
         //  저장 
         memberRepository.save(member); // 실패 시 예외 발생
     }
+    
+    public MemberLoginResponseDTO signUpKakao(MemberSignUpRequestDTO dto, String kakaoId) { // kakao 로그인 (최초) => devlog.com 사이트 통한 회원가입 => 바로 서비스 이용
+
+    	log.info("email = {}", dto.getMemberEmail());
+    	log.info("pw = {}", dto.getMemberPw());
+    	System.out.println(dto);
+
+        // 이메일 중복 체크 
+        if (memberRepository.existsByMemberEmail(dto.getMemberEmail())) {
+            throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+        }
+
+        // [A] ///////////////////////////////////        
+        // 기본 레벨 조회 (LV1) 
+        Level defaultLevel = levelRepository.findById(1)
+                .orElseThrow(() -> new IllegalStateException("기본 레벨이 존재하지 않습니다."));
+
+        // Member Entity 생성 
+        Member member = Member.builder()
+                .memberEmail(dto.getMemberEmail())
+                .memberPw(passwordEncoder.encode(dto.getMemberPw())) // passwordEncoder	반드시 Service에서
+                .memberName(dto.getMemberName())
+                .memberNickname(dto.getMemberNickname())
+                .memberTel(dto.getMemberTel())
+                .memberCareer(dto.getMemberCareer())
+                .memberAdmin(dto.getMemberAdmin() != null ? dto.getMemberAdmin() : Status.N) //	null 방어 처리
+                .memberSubscribe(dto.getMemberSubscribe() != null ? dto.getMemberSubscribe() : Status.N) //	null 방어 처리
+                .memberLevel(defaultLevel) // 기본 Level	클라이언트가 못 건드리게
+                .build();
+
+        // MEMBER TABLE 저장 
+        memberRepository.save(member); // 실패 시 예외 발생 ==> 저장되면 이 member의 memberNo 생성됨
+        
+        // [B] ///////////////////////////////////        
+        // SocialLogin Entity 생성 
+        //String kakaoId = (String)session.getAttribute("kakaoId");
+        log.info("kakaoId = {}", kakaoId);
+        SocialLogin socialLogin = SocialLogin.builder()
+        		.provider("kakao")
+        		.providerId(kakaoId)
+        		.memberNo(member)
+        		.build();
+
+        // SOCIAL_LOGIN TABLE 저장        
+        kakaoSocialLoginRepository.save(socialLogin); // 실패 시 예외 발생
+        
+        // [C] ///////////////////////////////////        
+        // MemberLoginResponseDTO 생성해서 반환해 주기
+    	// 이제 MemberLoginResponseDTO 만들자 with MemberSignUpRequestDTO dto
+        
+        String role =  dto.getMemberAdmin() == Status.N ? "ROLE_USER" : "ROLE_ADMIN";
+  
+        //Level level = member.getMemberLevel(); // LAZY 초기화 (트랜잭션 안)
+        // 기본 레벨 조회 (LV1): 이거 위에서 했다. 그거 그대로 가져다 쓴다. 
+        //Level defaultLevel = levelRepository.findById(1)
+        //        .orElseThrow(() -> new IllegalStateException("기본 레벨이 존재하지 않습니다."));
+        LevelDTO levelDTO = new LevelDTO(
+        		defaultLevel.getLevelNo(),
+        		defaultLevel.getTitle(),
+        		defaultLevel.getRequiredTotalExp()
+        );        	
+        
+        // 위에서 member entity 조회하여 memberNo를 포함함 모든 필드 읽어와야 MemberLoginResponseDTO 만들수 있다.
+        Member member2 = memberRepository
+                .findByMemberEmailAndMemberDelFl(dto.getMemberEmail(), Status.N)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("회원이 존재하지 않습니다.") // 바로 위에서 저장한 거라, 이게 발생하면 안됨
+                );
+
+        
+        MemberLoginResponseDTO memberKakaoDTO = new MemberLoginResponseDTO(
+        		member2.getMemberNo(),
+        		member2.getMemberEmail(),
+        		member2.getMemberNickname(),
+                role,
+                member2.getMemberAdmin(),
+                member2.getMemberSubscribe(),
+                member2.getMemberDelFl(),
+                member2.getMemberCareer(),
+                member2.getProfileImg(),
+                member2.getMyInfoIntro(),
+                member2.getMyInfoGit(),
+                member2.getMyInfoHomepage(),
+                member2.getSubscriptionPrice(),
+                member2.getBeansAmount(),
+                member2.getCurrentExp(),
+                member2.getMCreateDate(),
+                levelDTO
+                );        
+        
+        return memberKakaoDTO;
+    }    
+    
+    
+    
 }

--- a/Devlog/src/main/resources/application.yml
+++ b/Devlog/src/main/resources/application.yml
@@ -34,6 +34,12 @@ spring :
             options:
                model: gpt-4o-mini
 
+kakao:
+  client-id: ${KAKAO_REST_API_KEY}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI} 
+
+
      
 logging:
   level:

--- a/Devlog/src/main/resources/static/js/member/login.js
+++ b/Devlog/src/main/resources/static/js/member/login.js
@@ -74,6 +74,14 @@ if (loginFrm != null) {
 }
 
 
+// 카카오 소셜로그인
+const kakaoLoginBtn = document.getElementById("kakaoLoginBtn");
+
+kakaoLoginBtn.addEventListener("click", function () {
+            // DevLog 서비스 서버로 이동
+            window.location.href = "/app/login/kakao";
+});
+
 
 // 자바스크립트 쿠키 얻어오기: key를 전달하면, value얻는 JS함수
 function getCookie(key) {

--- a/Devlog/src/main/resources/templates/member/login.html
+++ b/Devlog/src/main/resources/templates/member/login.html
@@ -67,9 +67,9 @@
                     <div class="divider">OR</div>
         
                     <!-- 카카오 로그인 -->
-                    <button type="button" class="btn-kakao">
-                        <img th:src="@{/images/member/kakao_balloon_simul.png}" class="kakao-icon" alt="">
-                        카카오 계정으로 로그인
+                    <button type="button" class="btn-kakao" id="kakaoLoginBtn">
+                        <img th:src="@{/images/member/topic_ballon.png}" class="kakao-icon" alt="">
+                        카카오 로그인
                     </button>
                 </form>
             </div>

--- a/Devlog/src/main/resources/templates/member/signUpKakao.html
+++ b/Devlog/src/main/resources/templates/member/signUpKakao.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원가입</title>
+
+    <link rel="stylesheet" th:href="@{/css/member/signUp.css}">
+    <link rel="stylesheet" th:href="@{/css/common/font.css}">
+</head>
+
+<body>
+
+    <main>
+        <!-- 헤더 -->
+        <header class="main-header">header</header>
+        <!-- header.html (fragment) 추가 -->
+        <!-- <th:block th:replace="~{/common/header}">header.html</th:block> -->
+        <!-- 또는 -->
+        <!-- <div th:replace="common/header :: header"></div> -->
+
+        <!-- 네비게이션 -->
+        <nav class="main-nav"></nav>
+        <!--  ###################################################### -->
+
+        <div class="container-wrapper"> 
+            <h2 class="title fw-800">필수 회원정보 입력</h2>
+            <div class="container">
+                <div class="signup-box">
+
+                    <!-- <h2 class="title">회원가입</h2> -->
+
+                    <form th:action="@{/member/signUpKakao}" method="POST" name="signUpFrm" id="signUpFrm">
+
+                        <!-- 이메일 -->
+                        <label class="label" for="memberEmail">아이디(이메일) <span class="required">*</span></label>
+                        <div class="row">
+                            <input type="email" class="input" name="memberEmail" id="memberEmail"
+                                placeholder="이메일을 입력해 주세요" maxlength="30" autocomplete="off">
+                            <button id="sendAuthKeyBtn" type="button" class="btn-gray">인증 번호 받기</button>
+                        </div>
+                        <p class="desc" id="emailMessage">메일을 받을 수 있는 이메일을 입력해 주세요.</p>
+
+                        <!-- 인증번호 -->
+                        <label class="label" for="authKey">인증번호 <span class="required">*</span></label>
+                        <div class="row">
+                            <input type="text" name="authKey" id="authKey" class="input" 
+                                placeholder="이메일로 받은 인증번호 입력 후 인증하기 버튼을 클릭해 주세요">
+                            <button id="checkAuthKeyBtn" type="button" class="btn-gray">인증 하기</button>
+                        </div>
+                        <p class="desc" id="authKeyMessage"></p>
+                        <!-- 인증번호가 일치하지 않습니다 -->
+
+                        <div class="spaceholder"><p><br></p></div>
+
+                        <!-- 비밀번호 -->
+                        <label class="label" for="memberPw">비밀번호 <span class="required">*</span></label>
+                        <input type="password" name="memberPw" id="memberPw" class="input" 
+                            placeholder="비밀번호를 입력해주세요" maxlength="20">
+                        <p class="desc" id="pwMessage">영어,숫자,특수문자(!,@,#,-,_) 6~20자로 사이로 입력해주세요.</p>
+
+                        <!-- 비밀번호 확인 -->
+                        <label class="label" for="memberPwConfirm">비밀번호 확인 <span class="required">*</span></label>
+                        <input type="password" name="memberPwConfirm" id="memberPwConfirm" class="input" 
+                            placeholder="비밀번호 확인을 입력해주세요"  maxlength="20">
+                        <p class="desc"id="pwCheckMessage">위에서 입력하신 비밀번호와 동일하게 입력해주세요.</p>
+
+                        <!-- 이름 -->
+                        <label class="label" for="memberName">이름 <span class="required">*</span></label>
+                        <input type="text" name="memberName" id="memberName" class="input" 
+                            placeholder="이름을 입력해주세요" maxlength="10" >
+                        <p class="desc" id="nameMessage">유효한 이름을 입력해주세요 (예시: 홍길동)</p>
+
+                        <!-- 닉네임 -->
+                        <label class="label" for="memberNickname">닉네임 <span class="required">*</span></label>
+                        <input type="text" name="memberNickname" id="memberNickname" class="input" 
+                            placeholder="닉네임을 입력해주세요" maxlength="10" >
+                        <p class="desc" id="nicknameMessage">한글, 영어, 숫자로만 2~10자</p>
+
+                        <!-- 전화번호 -->
+                        <label class="label" for="memberTel">전화번호 <span class="required">*</span></label>
+                        <input type="text" name="memberTel" id="memberTel" class="input" 
+                            placeholder="(- 없이 숫자만 입력)" maxlength="11">
+                        <p class="desc" id="telMessage">전화번호를 입력해주세요 (- 제외)</p>
+
+                        <!-- 경력사항 -->
+                        <label class="label" for="memberCareer">경력사항 <span class="required">*</span></label>
+                        <input type="text" name="memberCareer" id="memberCareer" class="input" 
+                            placeholder="개발 경력(개발년차)를 입력해주세요">
+                        <p class="desc" id="careerMessage">유효한 경력사항을 입력해주세요 (예시: 백엔드 3년차)</p>
+
+
+                        <!-- 이메일 수신 -->
+                        <label class="check fw-600" for="memberSubscribe">
+                            <!-- 체크되면 브라우저는 무조건 "on" 을 전송함 => value="Y" 로 enums와 맞춰야함 -->
+                            <input type="checkbox" name="memberSubscribe" id="memberSubscribe" value="Y">
+                            이메일 수신동의 (회원 전용 정보 제공 메일 수신에 동의합니다)
+                        </label>
+
+
+                        <div class="spaceholder"><p><br></p></div>
+
+                        <!-- 가입 버튼 -->
+                        <div class="btn-join-wrapper">
+                            <button type="submit" id="signUpBtn" class="btn-join">필수 회원정보 입력</button>
+                        </div>
+
+
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!--  ###################################################### -->
+        <footer class="main-footer">footer</footer>
+        <!-- footer.html 추가 -->
+        <!-- <th:block th:replace="~{common/footer}">footer.html</th:block> -->
+        <!-- 또는 -->
+        <!-- <div th:replace="common/footer :: footer"></div> -->
+
+    </main>
+
+    <!-- 알림창 띄우기 -->
+    <script th:inline="javascript"> 
+        const message = /*[[${message}]]*/ "전달 받은 message";
+        if(message != null) alert(message); // message12가 없으면 null값
+    </script>
+
+    <!-- login.js 추가 -->
+    <script th:src="@{/js/member/signUp.js}"></script>
+
+</body>
+</html>


### PR DESCRIPTION
FEAT. 카카오 소셜 로그인 기능을 추가하였습니다. 머지부탁드립니다.

그리고, 이 기능사용을 위해서는 아래 단계를 수행해 주세요.

0) application.yml에 아래 kakao부분이 추가되었으므로, Gradle업데이트 해주세요.
kakao:
  client-id: ${KAKAO_REST_API_KEY}
  client-secret: ${KAKAO_CLIENT_SECRET}
  redirect-uri: ${KAKAO_REDIRECT_URI} 

1)  카카오 developers에 가셔서 앱등록 하시고 다름의 3 key를 STS4 devlog Run/Run Configurations/Environment 변수로 Key Value로 등록필요합니다.
"KAKAO_CLIENT_SECRET": your_key
"KAKAO_REDIRECT_URI": your_key
"KAKAO_REST_API_KEY": your_key

2) SOCIAL_LOG 테이블 키 생성필요합니다.
SELECT * FROM "SOCIAL_LOGIN";
SELECT SEQ_SOCIAL_LOGIN_NO.NEXTVAL from dual; 
DELETE FROM "SOCIAL_LOGIN"; 

-- 기존 시퀀스 삭제
DROP SEQUENCE SEQ_SOCIAL_LOGIN_NO; 
-- 시퀀스 생성
CREATE SEQUENCE SEQ_SOCIAL_LOGIN_NO START WITH 1 NOCACHE;

COMMIT;

3) 또한 SOCIAL_LOGIN 테이블 변경 필요합니다.
 ALTER TABLE SOCIAL_LOGIN ADD CONSTRAINT UK_SOCIAL_LOGIN UNIQUE (PROVIDER, PROVIDER_ID);